### PR TITLE
Release: Bump chart versions

### DIFF
--- a/releases/capi/helm/Chart.yaml
+++ b/releases/capi/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: capi
-version: 0.10.0
+version: 0.11.0
 description: Helm chart for CF API components
 type: application
 apiVersion: v2

--- a/releases/cf-networking/helm/Chart.yaml
+++ b/releases/cf-networking/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: cf-networking
-version: 0.8.0
+version: 0.9.0
 description: Helm chart for CF Networking components
 type: application
 apiVersion: v2

--- a/releases/credhub/helm/Chart.yaml
+++ b/releases/credhub/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: credhub
-version: 0.8.0
+version: 0.9.0
 description: Helm chart for CredHub components
 type: application
 apiVersion: v2

--- a/releases/diego/helm/Chart.yaml
+++ b/releases/diego/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: diego
-version: 0.11.0
+version: 0.12.0
 description: Helm chart for Diego components
 type: application
 apiVersion: v2

--- a/releases/log-cache/helm/Chart.yaml
+++ b/releases/log-cache/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: log-cache
-version: 0.7.0
+version: 0.8.0
 description: Helm chart for Log Cache components
 type: application
 apiVersion: v2

--- a/releases/loggregator-agent/helm/Chart.yaml
+++ b/releases/loggregator-agent/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: loggregator-agent
-version: 0.8.0
+version: 0.9.0
 description: Helm chart for Loggregator Agent components
 type: application
 apiVersion: v2

--- a/releases/loggregator/helm/Chart.yaml
+++ b/releases/loggregator/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: loggregator
-version: 0.7.0
+version: 0.8.0
 description: Helm chart for Loggregator components
 type: application
 apiVersion: v2

--- a/releases/nfs-volume/helm/Chart.yaml
+++ b/releases/nfs-volume/helm/Chart.yaml
@@ -1,6 +1,6 @@
 name: nfs-volume-release
 apiVersion: v2
-version: 0.3.0
+version: 0.4.0
 description: A Helm chart for deploying NFS Volume Release components
 # renovate: dataSource=docker depName=nfs-volume-release packageName=ghcr.io/cloudfoundry/k8s/nfsbroker
 appVersion: 7.49.0

--- a/releases/routing/helm/Chart.yaml
+++ b/releases/routing/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: routing
-version: 0.11.0
+version: 0.12.0
 description: Helm chart for Gorouter components
 type: application
 apiVersion: v2

--- a/releases/uaa/helm/Chart.yaml
+++ b/releases/uaa/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: uaa
-version: 0.11.0
+version: 0.12.0
 description: A Helm chart for UAA
 type: application
 apiVersion: v2


### PR DESCRIPTION
| Chart | Version Bump |
|---|---|
| capi | 0.10.0 -> 0.11.0 |
| cf-networking | 0.8.0 -> 0.9.0 |
| credhub | 0.8.0 -> 0.9.0 |
| diego | 0.11.0 -> 0.12.0 |
| log-cache | 0.7.0 -> 0.8.0 |
| loggregator | 0.7.0 -> 0.8.0 |
| loggregator-agent | 0.8.0 -> 0.9.0 |
| nfs-volume | 0.3.0 -> 0.4.0 |
| routing | 0.11.0 -> 0.12.0 |
| uaa | 0.11.0 -> 0.12.0 |
