### PR TITLE
Cleanup certs when deleting cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,6 @@ bootstrap-complete: create-org
 up: create-kind init install
 
 down: delete-kind
+	@ rm -rf temp
 
 PHONY: install login create-kind delete-kind up down create-org bootstrap bootstrap-complete


### PR DESCRIPTION
So `make down` will always give a "clean slate"