### PR TITLE
Add helper script for running cats locally

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,1 +1,1 @@
-cats-config.yaml
+cats-config.json

--- a/scripts/cats.sh
+++ b/scripts/cats.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+CATS_PATH="${CATS_PATH:-../cf-acceptance-tests}"
+CATS_TEMPLATE="${CATS_TEMPLATE:-.github/cats-config.tpl}"
+CATS_CONFIG="${CATS_CONFIG:-.github/cats-config.json}"
+
+[ ! -d "${CATS_PATH}" ] && echo "Error: CATS_PATH '${CATS_PATH}' does not exist, ensure it points to a local clone of cf-acceptance-tests." && exit 1
+[ ! -f "${CATS_TEMPLATE}" ] && echo "Error: CATS_TEMPLATE '${CATS_TEMPLATE}' does not exist, ensure it points to a valid template file." && exit 1
+
+source temp/secrets.sh
+python3 -c 'import os,sys;[sys.stdout.write(os.path.expandvars(l)) for l in sys.stdin]' < ${CATS_TEMPLATE} > ${CATS_CONFIG}
+echo "CATS configuration rendered to ${CATS_CONFIG}."
+
+if [ -n "${RENDER_ONLY}" ]; then
+  exit 0
+fi
+
+CONFIG=$(realpath ${CATS_CONFIG}) ${CATS_PATH}/bin/test --timeout=180m --procs=4 --flake-attempts=1


### PR DESCRIPTION
By default it uses `.github/cats-config.tpl`, inserts the template values and runs CATS. If `CATS_TEMPLATE` is provided, this file is used instead.

Path to local cf-acceptance-tests repo defaults to `../cf-acceptance-tests`, overwritten with `CATS_PATH`. If `CATS_CONFIG` is provided, it's passed as is to the test script of CATS.
