### PR TITLE
Revert "Update dependency cloudfoundry/k8s-garden-client to v0.6.0"

### DIFF
--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -351,8 +351,6 @@ releases:
           - ssh-proxy
           - cf-tcp-router
       - loggregatorCertificateSecret: all-in-one-tls
-      - locket:
-          certificateSecret: all-in-one-tls
 
     hooks:
       - events: ["presync"]

--- a/values.yaml.gotmpl
+++ b/values.yaml.gotmpl
@@ -3,7 +3,7 @@ certsDir: "./temp/certs"
 
 versions:
   # renovate: dataSource=github-releases depName=cloudfoundry/k8s-garden-client
-  k8sRep: "0.6.0"
+  k8sRep: "0.5.0"
   # renovate: dataSource=github-releases depName=cloudfoundry/k8s-policy-agent
   policyAgent: "0.3.0"
   # renovate: dataSource=docker depName=cloudfoundry/cflinuxfs4-release packageName=ghcr.io/cloudfoundry/k8s/cflinuxfs4


### PR DESCRIPTION
Reverts cloudfoundry/kind-deployment#230

Breaks [file-based service bindings] CATS tests.

```
image size 1095503872 exceeds container disk limit 1073741824
```