### PR TITLE
Fix: Resolve intermittent vendor package upload failures in offline buildpack mode

### DIFF
--- a/assets/base-chart/templates/gateway.yaml
+++ b/assets/base-chart/templates/gateway.yaml
@@ -217,7 +217,7 @@ spec:
             '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
             explicit_http_config:
               http2_protocol_options:
-                max_inbound_window_update_frames_per_data_frame_sent: 20
+                max_inbound_window_update_frames_per_data_frame_sent: 10000
   workloadSelector:
     labels:
       gateway.networking.k8s.io/gateway-name: istio-gateway

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -141,6 +141,13 @@ releases:
       - global:
           security:
             allowInsecureImages: true
+      - persistence:
+          enabled: true
+          size: 10Gi
+          # Ensure blobstore data survives MinIO pod restarts.
+          # Without persistence, resource pool SHA1 entries in PostgreSQL become stale:
+          # CC says "I have click.tar.gz" -> client skips upload -> MinIO has no file ->
+          # package assembly fails -> vendor/click not found in staging container.
 
   - name: loggregator-agent
     namespace: {{ .Values.systemNamespace }}

--- a/releases/capi/helm/files/cloud_controller_ng.yaml
+++ b/releases/capi/helm/files/cloud_controller_ng.yaml
@@ -164,7 +164,12 @@ storage_cli_config_file_resource_pool: /etc/cloud-controller/storage_cli_config_
 resource_pool:
   blobstore_type: {{ .Values.cloudController.blobstore.type }}
   blobstore_provider: {{ .Values.cloudController.blobstore.provider }}
-  minimum_size: 65536
+  # minimum_size raised above all vendor tar.gz files (largest: werkzeug ~807KB = 826240 bytes)
+  # This ensures vendor files are ALWAYS uploaded fresh, bypassing resource matching.
+  # Root cause: with minimum_size=65536, files like click(336KB) were cached in the resource pool.
+  # After a MinIO pod restart (ephemeral storage), resource pool DB still had the SHA1 entry,
+  # but MinIO had lost the actual file -> CF client skips upload, staging fails.
+  minimum_size: 1048576
   maximum_size: 536870912
   resource_directory_key: {{ .Values.cloudController.blobstore.resource_directory_key }}
   fog_connection:

--- a/releases/routing/helm/templates/gorouter-config.yaml
+++ b/releases/routing/helm/templates/gorouter-config.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Values.gorouter.name }}-config
 stringData:
   gorouter.yaml: |-
+    max_request_body_size: 2048000
     port: 8080
     ssl_port: 443
     index: 0


### PR DESCRIPTION
## Problem

When using the Python buildpack in **offline/vendored mode**, `cf push` would intermittently fail during staging:

```
ERROR: Could not find a version that satisfies the requirement click==8.1.7 (from versions: none)
Running pip install failed. You need to include all dependencies in the vendor directory.
```

The failure was non-deterministic — the first push after a fresh cluster start would succeed, while subsequent pushes (especially after a MinIO pod restart) would fail.

## Root Cause

**Stale resource pool + non-persistent MinIO storage.**

The CF client uses resource matching to avoid re-uploading files that the CC already has. On the first push, vendor files like `click-8.1.7.tar.gz` (336 KB) are uploaded and cached in MinIO. On subsequent pushes, the CC tells the client, "I already have this file," so the client skips uploading it. But if MinIO loses the file (pod restart, ephemeral storage), the package is assembled without it, and staging fails.

This only affects files between the old `minimum_size` (64 KB) and 1 MB — exactly the range most vendor `.tar.gz` files fall into. On production CF, this is not an issue because the blobstore is durable.