### PR TITLE
Change CATS branch to a stable version

### DIFF
--- a/.github/actions/setup-cf-tests/action.yaml
+++ b/.github/actions/setup-cf-tests/action.yaml
@@ -12,7 +12,7 @@ inputs:
   test-branch:
     description: 'CF test repository branch to checkout'
     required: false
-    default: 'develop'
+    default: 'release-candidate'
   config-template:
     description: 'Config template file path'
     required: true


### PR DESCRIPTION
`develop` branch of cf-acceptance-tests already requires java-buildpack v5 which is not part of cf-deployment. To avoid this mismatch, we switch to a more stable state of CATS