### PR TITLE
Release: Bump chart versions

### DIFF
--- a/releases/capi/helm/Chart.yaml
+++ b/releases/capi/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: capi
-version: 0.24.0
+version: 0.25.0
 description: Helm chart for CF API components
 type: application
 apiVersion: v2

--- a/releases/cf-networking/helm/Chart.yaml
+++ b/releases/cf-networking/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: cf-networking
-version: 0.18.0
+version: 0.19.0
 description: Helm chart for CF Networking components
 type: application
 apiVersion: v2

--- a/releases/credhub/helm/Chart.yaml
+++ b/releases/credhub/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: credhub
-version: 0.17.0
+version: 0.18.0
 description: Helm chart for CredHub components
 type: application
 apiVersion: v2

--- a/releases/diego/helm/Chart.yaml
+++ b/releases/diego/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: diego
-version: 0.21.0
+version: 0.22.0
 description: Helm chart for Diego components
 type: application
 apiVersion: v2

--- a/releases/routing/helm/Chart.yaml
+++ b/releases/routing/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: routing
-version: 0.24.0
+version: 0.25.0
 description: Helm chart for Gorouter components
 type: application
 apiVersion: v2

--- a/releases/uaa/helm/Chart.yaml
+++ b/releases/uaa/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: uaa
-version: 0.21.0
+version: 0.22.0
 description: A Helm chart for UAA
 type: application
 apiVersion: v2


### PR DESCRIPTION
| Chart | Version Bump |
|---|---|
| capi | 0.24.0 -> 0.25.0 |
| cf-networking | 0.18.0 -> 0.19.0 |
| credhub | 0.17.0 -> 0.18.0 |
| diego | 0.21.0 -> 0.22.0 |
| routing | 0.24.0 -> 0.25.0 |
| uaa | 0.21.0 -> 0.22.0 |
