### PR TITLE
Use upstream ruby version

### DIFF
--- a/releases/capi/cloud-controller.Dockerfile
+++ b/releases/capi/cloud-controller.Dockerfile
@@ -11,7 +11,7 @@ RUN STORAGE_CLI_RELEASE_VERSION=$(sed -n 's/.*storage_cli_version="\([^"]*\)".*/
     curl https://github.com/cloudfoundry/storage-cli/releases/download/v${STORAGE_CLI_RELEASE_VERSION}/storage-cli-${STORAGE_CLI_RELEASE_VERSION}-linux-${TARGETARCH} -L -o /usr/local/bin/storage-cli && \
     chmod +x /usr/local/bin/storage-cli
 
-FROM ruby:4.0.3-slim
+FROM ruby:3.3.10-slim
 
 RUN apt update && apt install -y postgresql-client libpq-dev default-libmysqlclient-dev libyaml-dev build-essential zip git procps && useradd -u 1000 -d /nonexistent -s /sbin/nologin --no-create-home vcap && \
     rm -rf /var/lib/apt/lists/* 


### PR DESCRIPTION
We should always stick to the version defined by [upstream](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/.ruby-version).