### PR TITLE
feat: Drop SHA1 support for the Diego SSH proxy

### DIFF
--- a/releases/diego/helm/templates/ssh-proxy-config.yaml
+++ b/releases/diego/helm/templates/ssh-proxy-config.yaml
@@ -19,6 +19,7 @@ stringData:
       "allowed_ciphers": "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr",
       "allowed_macs": "hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512",
       "allowed_key_exchanges": "curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256",
+      "allowed_host_key_algorithms": "rsa-sha2-256,rsa-sha2-512",
       "cc_api_url": "https://cloud-controller.{{ .Release.Namespace }}.svc.cluster.local:9024",
       "cc_api_ca_cert": "/etc/ssl/certs/ssh-proxy/ca.crt",
       "idle_connection_timeout": "300s",


### PR DESCRIPTION
- Drop SHA1 support for the Diego SSH proxy