### PR TITLE
Enable validation cf-deployment

### DIFF
--- a/.github/workflows/kind-cats.yaml
+++ b/.github/workflows/kind-cats.yaml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
+    inputs:
+      fresh-validation:
+        description: 'Use versions of cf-deployment from the develop branch'
+        type: boolean
+        required: false
+        default: false
   pull_request:
     branches:
       - main
@@ -49,6 +55,14 @@ jobs:
           KIND_VERSION: "0.31.0"
           # renovate: dataSource=github-releases depName=helmfile/helmfile
           HELMFILE_VERSION: "1.5.2"
+      - name: Use develop versions of cf-deployment
+        id: pre_validation
+        if: steps.check_changes.outputs.skip != 'true' && github.event_name == 'workflow_dispatch' && github.event.inputs.fresh-validation == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip3 install -r scripts/requirements.txt
+          python3 scripts/sync-cf-deployment-versions.py --ref develop
       - name: Run make up
         if: steps.check_changes.outputs.skip != 'true'
         run: |

--- a/.github/workflows/kind-smoke.yaml
+++ b/.github/workflows/kind-smoke.yaml
@@ -11,8 +11,8 @@ on:
         type: boolean
         required: false
         default: true
-      pre-validation:
-        description: 'Use pre-validated versions of cf-deployment from the develop branch'
+      fresh-validation:
+        description: 'Use versions of cf-deployment from the develop branch'
         type: boolean
         required: false
         default: false
@@ -68,9 +68,9 @@ jobs:
           KIND_VERSION: "0.31.0"
           # renovate: dataSource=github-releases depName=helmfile/helmfile
           HELMFILE_VERSION: "1.5.2"
-      - name: Use pre-validated version of cf-deployment
+      - name: Use develop versions of cf-deployment
         id: pre_validation
-        if: steps.check_changes.outputs.skip != 'true' && github.event_name == 'workflow_dispatch' && github.event.inputs.pre-validation == 'true'
+        if: steps.check_changes.outputs.skip != 'true' && github.event_name == 'workflow_dispatch' && github.event.inputs.fresh-validation == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/kind-smoke.yaml
+++ b/.github/workflows/kind-smoke.yaml
@@ -11,6 +11,11 @@ on:
         type: boolean
         required: false
         default: true
+      pre-validation:
+        description: 'Use pre-validated versions of cf-deployment from the develop branch'
+        type: boolean
+        required: false
+        default: false
   schedule:
     - cron: '0 7 * * 1'
 
@@ -63,6 +68,14 @@ jobs:
           KIND_VERSION: "0.31.0"
           # renovate: dataSource=github-releases depName=helmfile/helmfile
           HELMFILE_VERSION: "1.5.2"
+      - name: Use pre-validated version of cf-deployment
+        id: pre_validation
+        if: steps.check_changes.outputs.skip != 'true' && github.event_name == 'workflow_dispatch' && github.event.inputs.pre-validation == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip3 install -r scripts/requirements.txt
+          python3 scripts/sync-cf-deployment-versions.py --ref develop
       - name: Run make up (default)
         if: steps.check_changes.outputs.skip != 'true' && github.event_name == 'pull_request'
         run: make up


### PR DESCRIPTION
prerequisite: https://github.com/cloudfoundry/kind-deployment/pull/423

It adds a parameter `fresh-validation` to the smoke tests. When set to true, it will test the versions currently pre-validated by `cf-deployment`.