### PR TITLE
Ensure versions in install table

### DIFF
--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -5,7 +5,7 @@ helmDefaults:
   recreatePods: false
   force: false
   createNamespace: true
-  args:
+  syncArgs:
     - --hide-notes
 
 environments:


### PR DESCRIPTION
The problem is that `--hide-notes` is not available for `helm list` which is used by helmfile to determine the state of releases. It just fails and does not output anything.

Before the change:

```
make up
...

UPDATED RELEASES:
NAME                NAMESPACE      CHART                                VERSION   DURATION
cilium              kube-system    cilium/cilium                                       29s
istio-base          istio-system   istio/base                                           8s
istiod              istio-system   istio/istiod                                        14s
base                cf-system      ./assets/base-chart                                  2s
loggregator         cf-system      cloudfoundry-k8s/loggregator                        13s
loggregator-agent   cf-system      cloudfoundry-k8s/loggregator-agent                  19s
minio               cf-system      bitnami/minio                                       27s
nats                cf-system      nats/nats                                           33s
postgresql          cf-system      bitnami/postgresql                                  41s
locket              cf-system      cloudfoundry-k8s/diego                               3s
gorouter            cf-system      cloudfoundry-k8s/routing                            16s
uaa                 cf-system      cloudfoundry-k8s/uaa                                31s
credhub             cf-system      cloudfoundry-k8s/credhub                            10s
log-cache           cf-system      cloudfoundry-k8s/log-cache                          41s
tcp-routing         cf-system      cloudfoundry-k8s/routing                            51s
diego               cf-system      cloudfoundry-k8s/diego                             1m3s
k8s-rep             cf-system      cloudfoundry-k8s/k8s-rep                            15s
capi                cf-system      cloudfoundry-k8s/capi                               42s
nfs-volume          cf-system      cloudfoundry-k8s/nfs-volume                          6s
tps-watcher         cf-system      cloudfoundry-k8s/capi                               10s
cf-networking       cf-system      cloudfoundry-k8s/cf-networking                      12s
policy-agent        cf-system      cloudfoundry-k8s/policy-agent                        4s
route-emitter       cf-system      cloudfoundry-k8s/diego                               4s
```

After:

```
make up
...
UPDATED RELEASES:
NAME                NAMESPACE      CHART                                VERSION    DURATION
cilium              kube-system    cilium/cilium                        1.18.4          31s
istio-base          istio-system   istio/base                           1.29.1           1s
istiod              istio-system   istio/istiod                         1.29.1           6s
base                cf-system      ./assets/base-chart                  0.0.1            1s
loggregator-agent   cf-system      cloudfoundry-k8s/loggregator-agent   8.3.22           6s
loggregator         cf-system      cloudfoundry-k8s/loggregator         107.0.31         7s
minio               cf-system      bitnami/minio                        17.0.21         14s
nats                cf-system      nats/nats                            2.12.4          21s
postgresql          cf-system      bitnami/postgresql                   16.7.27         23s
locket              cf-system      cloudfoundry-k8s/diego               2.138.0          1s
gorouter            cf-system      cloudfoundry-k8s/routing             0.384.0          5s
uaa                 cf-system      cloudfoundry-k8s/uaa                 78.16.0         11s
credhub             cf-system      cloudfoundry-k8s/credhub             2.15.8           5s
log-cache           cf-system      cloudfoundry-k8s/log-cache           3.2.10           8s
tcp-routing         cf-system      cloudfoundry-k8s/routing             0.384.0          9s
diego               cf-system      cloudfoundry-k8s/diego               2.138.0         14s
k8s-rep             cf-system      cloudfoundry-k8s/k8s-rep             0.6.4            7s
capi                cf-system      cloudfoundry-k8s/capi                1.236.0         18s
tps-watcher         cf-system      cloudfoundry-k8s/capi                1.236.0          1s
nfs-volume          cf-system      cloudfoundry-k8s/nfs-volume          7.61.0           2s
cf-networking       cf-system      cloudfoundry-k8s/cf-networking       3.115.0          3s
policy-agent        cf-system      cloudfoundry-k8s/policy-agent        0.3.3            2s
route-emitter       cf-system      cloudfoundry-k8s/diego               2.138.0          2s
```