### PR TITLE
Bump capi to fix crashing cc-worker

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,7 +1,7 @@
 charts:
   capi:
     url: cloudfoundry-k8s/capi
-    version: 1.236.0
+    version: 1.236.1-fix1
   cfNetworking:
     url: cloudfoundry-k8s/cf-networking
     version: 3.115.0


### PR DESCRIPTION
`cc-worker` was crashing because of updated property file.