### PR TITLE
Stop managing `nfsVolume` version with renovate

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -41,7 +41,6 @@ charts:
     version: 2.12.4
   nfsVolume:
     url: cloudfoundry-k8s/nfs-volume
-    # renovate: dataSource=docker depName=ghcr.io/cloudfoundry/helm/nfs-volume
     version: 7.62.0
   policyAgent:
     url: cloudfoundry-k8s/policy-agent


### PR DESCRIPTION
The version management has been moved to https://github.com/cloudfoundry/kind-deployment/pull/445