### PR TITLE
CATS args passthrough

### DIFF
--- a/scripts/cats.sh
+++ b/scripts/cats.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Extra args are forwarded to bin/test, e.g. `bash scripts/cats.sh --focus="…"`.
 
 CATS_PATH="${CATS_PATH:-../cf-acceptance-tests}"
 CATS_TEMPLATE="${CATS_TEMPLATE:-.github/cats-config.tpl}"
 CATS_CONFIG="${CATS_CONFIG:-.github/cats-config.json}"
 
-[ ! -d "${CATS_PATH}" ] && echo "Error: CATS_PATH '${CATS_PATH}' does not exist, ensure it points to a local clone of cf-acceptance-tests." && exit 1
-[ ! -f "${CATS_TEMPLATE}" ] && echo "Error: CATS_TEMPLATE '${CATS_TEMPLATE}' does not exist, ensure it points to a valid template file." && exit 1
+if [ ! -d "${CATS_PATH}" ]; then
+  echo "Error: CATS_PATH '${CATS_PATH}' does not exist, ensure it points to a local clone of cf-acceptance-tests."
+  exit 1
+fi
+if [ ! -f "${CATS_TEMPLATE}" ]; then
+  echo "Error: CATS_TEMPLATE '${CATS_TEMPLATE}' does not exist, ensure it points to a valid template file."
+  exit 1
+fi
 
 source temp/secrets.sh
-python3 -c 'import os,sys;[sys.stdout.write(os.path.expandvars(l)) for l in sys.stdin]' < ${CATS_TEMPLATE} > ${CATS_CONFIG}
+python3 -c 'import os,sys;[sys.stdout.write(os.path.expandvars(l)) for l in sys.stdin]' < "${CATS_TEMPLATE}" > "${CATS_CONFIG}"
 echo "CATS configuration rendered to ${CATS_CONFIG}."
 
-if [ -n "${RENDER_ONLY}" ]; then
+if [ -n "${RENDER_ONLY:-}" ]; then
   exit 0
 fi
 
-CONFIG=$(realpath ${CATS_CONFIG}) ${CATS_PATH}/bin/test --timeout=180m --procs=4 --flake-attempts=1 "$@"
+CONFIG=$(realpath "${CATS_CONFIG}") "${CATS_PATH}/bin/test" --timeout=180m --procs=4 --flake-attempts=1 "$@"

--- a/scripts/cats.sh
+++ b/scripts/cats.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Extra args are forwarded to bin/test, e.g. `bash scripts/cats.sh --focus="…"`.
+
 CATS_PATH="${CATS_PATH:-../cf-acceptance-tests}"
 CATS_TEMPLATE="${CATS_TEMPLATE:-.github/cats-config.tpl}"
 CATS_CONFIG="${CATS_CONFIG:-.github/cats-config.json}"
@@ -15,4 +17,4 @@ if [ -n "${RENDER_ONLY}" ]; then
   exit 0
 fi
 
-CONFIG=$(realpath ${CATS_CONFIG}) ${CATS_PATH}/bin/test --timeout=180m --procs=4 --flake-attempts=1
+CONFIG=$(realpath ${CATS_CONFIG}) ${CATS_PATH}/bin/test --timeout=180m --procs=4 --flake-attempts=1 "$@"


### PR DESCRIPTION
I am currently playing with cf-on-kind to run CATS locally. For this I frequently run cats with `--focus` so it takes less time.

This change makes it possible to pass through args to CATS' `bin/test` and therefore pass `--focus` to it (first commit). It opens up this script to other use cases.

The second commit aligns this script a bit more with `init.sh` and `install.sh` and is only loosely related.

**Tested**:

1. invoking `bin/test` through the wrapper with `--help`

```bash
❯ ./scripts/cats.sh --help |  grep -C 3 usage

Ginkgo Version 2.32.0
---------------------
For usage information for a command, run ginkgo help COMMAND.
For usage information for the default command, run ginkgo help ginkgo or ginkgo help run.

The following commands are available:
  ginkgo or ginkgo run - ginkgo run <FLAGS> <PACKAGES> -- <PASS-THROUGHS>
exit status 1
```

2. Tracing the command it builds: 

```bash
set -e
TMPD=$(mktemp -d)
# fake CATS clone with a bin/test that just echoes CONFIG + args
mkdir -p "$TMPD/bin"
cat > "$TMPD/bin/test" <<'EOF'
#!/usr/bin/env bash
echo "CONFIG=$CONFIG"
echo "ARGS=$*"
EOF
chmod +x "$TMPD/bin/test"
# run the real wrapper, but pointed at the fake clone; skip render by pre-creating config
CATS_PATH="$TMPD" bash scripts/cats.sh --focus="app syslog tcp" --procs=2 --dry-run
echo "=== wrapper exit=$? ==="
rm -rf "$TMPD")
```
```
CATS configuration rendered to .github/cats-config.json.
CONFIG=/Users/mysuer/Workspace/public/cloudfoundry/kind-deployment/.github/cats-config.json
ARGS=--timeout=180m --procs=4 --flake-attempts=1 --focus=app syslog tcp --procs=2 --dry-run
=== wrapper exit=0 ===
```

---
🤖 Drafted with Claude Code (Claude Opus, v2.1.231). Human-reviewed before submission.