### PR TITLE
Stop using deprecated v2 API within Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 
 login:
 	@ . temp/secrets.sh; \
-	curl --silent --show-error --fail --insecure --retry 9 --retry-delay 5 --retry-all-errors --output /dev/null "https://api.cf.127-0-0-1.nip.io/v2/info"; \
+	curl --silent --show-error --fail --insecure --retry 9 --retry-delay 5 --retry-all-errors --output /dev/null "https://api.cf.127-0-0-1.nip.io/v3/info"; \
 	echo "API is ready. Logging in..."; \
 	cf login -a https://api.cf.127-0-0-1.nip.io -u ccadmin -p "$$CC_ADMIN_PASSWORD" --skip-ssl-validation
 


### PR DESCRIPTION
As v2 is deprecated and about to get removed we should maybe switch to v3 in the Makefile