### PR TITLE
Add otel-collector-release based on upstream helm

### DIFF
--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -173,6 +173,7 @@ releases:
     namespace: {{ .Values.systemNamespace }}
     chart: open-telemetry/opentelemetry-collector
     version: {{ .Values.charts.otelCollector.version }}
+    installed: {{ .Values.installOtelCollector }}
     needs:
       - {{ .Values.systemNamespace }}/base
     values:

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -21,6 +21,8 @@ repositories:
     url: https://istio-release.storage.googleapis.com/charts
   - name: bitnami
     url: https://charts.bitnami.com/bitnami
+  - name: open-telemetry
+    url: https://open-telemetry.github.io/opentelemetry-helm-charts
   - name: cilium
     url: https://helm.cilium.io/
   - name: cloudfoundry-k8s
@@ -166,6 +168,64 @@ releases:
           certificateSecret: all-in-one-tls
       - syslogAgent:
           certificateSecret: all-in-one-tls
+
+  - name: otel-collector
+    namespace: {{ .Values.systemNamespace }}
+    chart: open-telemetry/opentelemetry-collector
+    version: {{ .Values.charts.otelCollector.version }}
+    needs:
+      - {{ .Values.systemNamespace }}/base
+    values:
+      - mode: deployment
+        image:
+          repository: ghcr.io/cloudfoundry/k8s/otel-collector
+          tag: {{ .Values.charts.otelCollector.imageTag | quote }}
+        command:
+          name: ""
+        ports:
+          jaeger-compact:
+            enabled: false
+          jaeger-thrift:
+            enabled: false
+          jaeger-grpc:
+            enabled: false
+          zipkin:
+            enabled: false
+        alternateConfig:
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                  endpoint: 0.0.0.0:4317
+                http:
+                  endpoint: 0.0.0.0:4318
+          processors:
+            batch: {}
+            memory_limiter:
+              check_interval: 5s
+              limit_percentage: 80
+              spike_limit_percentage: 25
+          extensions:
+            health_check:
+              endpoint: ${env:MY_POD_IP}:13133
+          exporters:
+            debug:
+              verbosity: detailed
+          service:
+            extensions: [health_check]
+            pipelines:
+              metrics:
+                receivers: [otlp]
+                processors: [memory_limiter, batch]
+                exporters: [debug]
+              logs:
+                receivers: [otlp]
+                processors: [memory_limiter, batch]
+                exporters: [debug]
+              traces:
+                receivers: [otlp]
+                processors: [memory_limiter, batch]
+                exporters: [debug]
 
   - name: gorouter
     namespace: {{ .Values.systemNamespace }}

--- a/values.yaml.gotmpl
+++ b/values.yaml.gotmpl
@@ -4,6 +4,7 @@ systemNamespace: "cf-system"
 workloadsNamespace: "cf-workloads"
 
 installOptionalComponents: {{ "INSTALL_OPTIONAL_COMPONENTS" | env | default "true" }}
+installOtelCollector: {{ "INSTALL_OTEL_COLLECTOR" | env | default "false" }}
 secrets:
   dbPassword: {{ requiredEnv "DB_PASSWORD" }}
   blobstorePassword: {{ requiredEnv "BLOBSTORE_PASSWORD" }}

--- a/versions.yaml
+++ b/versions.yaml
@@ -42,6 +42,11 @@ charts:
   nfsVolume:
     url: cloudfoundry-k8s/nfs-volume
     version: 7.69.0
+  otelCollector:
+    # renovate: dataSource=helm depName=opentelemetry-collector packageName=open-telemetry/opentelemetry-collector
+    version: 0.172.0
+    # renovate: dataSource=github-releases depName=cloudfoundry/otel-collector-release
+    imageTag: "0.11.10"
   policyAgent:
     url: cloudfoundry-k8s/policy-agent
     # renovate: dataSource=github-releases depName=cloudfoundry/k8s-policy-agent


### PR DESCRIPTION
Uses upstream helm chart but our own otel distro

Requires https://github.com/cloudfoundry/cf-k8s-releases/pull/230 to have an image to deploy and https://github.com/cloudfoundry/otel-collector-release/pull/263 to have the health check component which is required by the upstream helm chart.

Also adds a new env var that determines if otel-collector is deployed or not.

---

Drafted by an AI coding harness, not yet carefully reviewed.